### PR TITLE
Fix small typo in link

### DIFF
--- a/docs/AssembleBody.md
+++ b/docs/AssembleBody.md
@@ -5,7 +5,7 @@ These parts make up the box that serves as the rover's main body and equipment b
 **Estimated Time:** 1 hour 15 minutes
 
 **Parts:**
-* 4 * [Printed corner pieces0(Print%20Body%20Box%20Corners.md)
+* 4 * [Printed corner pieces](Print%20Body%20Box%20Corners.md)
 * 4 * [385mm extrusion beams](Misumi%20HFS%203.md)
 * 4 * [245mm extrusion beams](Misumi%20HFS%203.md)
 * 2 * [Rocker joint body mount](AssemblePivotJoints.md)


### PR DESCRIPTION
AssemblyBody.md had a "Printed corner pieces" link that didn't show up
properly because a '0' was placed where a ']' should have been.